### PR TITLE
Fixed and improved asynchronous loading

### DIFF
--- a/application/libraries/Googlemaps.php
+++ b/application/libraries/Googlemaps.php
@@ -1205,6 +1205,7 @@ class Googlemaps {
 		$this->output_js_contents .= ');
 				
 				 ';
+
 		
 		$styleOutput = '';
 		if (count($this->styles)) {
@@ -1746,91 +1747,91 @@ class Googlemaps {
 		}
 		
 		if ($this->onboundschanged!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "bounds_changed", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "bounds_changed", function(event) {
     			'.$this->onboundschanged.'
   			});
 			';
 		}
 		if ($this->oncenterchanged!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "center_changed", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "center_changed", function(event) {
     			'.$this->oncenterchanged.'
   			});
 			';
 		}
 		if ($this->onclick!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "click", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "click", function(event) {
     			'.$this->onclick.'
   			});
 			';
 		}
 		if ($this->ondblclick!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "dblclick", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "dblclick", function(event) {
     			'.$this->ondblclick.'
   			});
 			';
 		}
 		if ($this->ondrag!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "drag", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "drag", function(event) {
     			'.$this->ondrag.'
   			});
 			';
 		}
 		if ($this->ondragend!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "dragend", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "dragend", function(event) {
     			'.$this->ondragend.'
   			});
 			';
 		}
 		if ($this->ondragstart!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "dragstart", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "dragstart", function(event) {
     			'.$this->ondragstart.'
   			});
 			';
 		}
 		if ($this->onidle!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "idle", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "idle", function(event) {
     			'.$this->onidle.'
   			});
 			';
 		}
 		if ($this->onmousemove!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "mousemove", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "mousemove", function(event) {
     			'.$this->onmousemove.'
   			});
 			';
 		}
 		if ($this->onmouseout!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "mouseout", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "mouseout", function(event) {
     			'.$this->onmouseout.'
   			});
 			';
 		}
 		if ($this->onmouseover!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "mouseover", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "mouseover", function(event) {
     			'.$this->onmouseover.'
   			});
 			';
 		}
 		if ($this->onresize!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "resize", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "resize", function(event) {
     			'.$this->onresize.'
   			});
 			';
 		}
 		if ($this->onrightclick!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "rightclick", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "rightclick", function(event) {
     			'.$this->onrightclick.'
   			});
 			';
 		}
 		if ($this->ontilesloaded!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "tilesloaded", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "tilesloaded", function(event) {
     			'.$this->ontilesloaded.'
   			});
 			';
 		}
 		if ($this->onzoomchanged!="") { 
-			$this->output_js_contents .= 'google.maps.event.addListener(map, "zoom_changed", function(event) {
+			$this->output_js_contents .= 'google.maps.event.addListener('.$this->map_name.', "zoom_changed", function(event) {
     			'.$this->onzoomchanged.'
   			});
 			';


### PR DESCRIPTION
I made the following changes to get this working in AJAX requests.  It works great now -- I hope you can pull these changes into the project.
1. Added $loadAsynchDelay config variable to help prevent issue where maps initialize before its elements finish loading.
2. Moved google.maps.InfoWindow constructor inside loadScript function, so it doesn't error out on asynchronous pages.
3. Added code (line 2117) to prevent Google Maps API from loading multiple times on subsequent AJAX calls.
4. Minor fix on line 2127 to kick off loadScript function on AJAX calls.

Thanks,
Mike
